### PR TITLE
Add data migration resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Infrastructure code for the provisioning of object storage for call centre data 
 
 ## Overview
 
-An S3 bucket is provisioned, along with an IAM user with suitable policy and credentials, for use with client applications such as [WinSCP](https://winscp.net/eng/index.php) and [Cyberduck](https://cyberduck.io/).
+An S3 bucket is provisioned for the storage of call centre data, along with an IAM 'accessor' user with suitable policy and credentials, which is intended for use with client applications such as [WinSCP](https://winscp.net/eng/index.php) and [Cyberduck](https://cyberduck.io/) to retrieve and upload objects to the bucket.
+
+An additionaal IAM 'migrator' user can be created by setting the boolean variable `data_migration_enabled` to `true` on a per-environment basis. This user is allowed to assume a role which permits retrieval of S3 objects from an external source bucket (specified by the `data_migration_source_bucket_arn` variable) for migration of data between an external S3 bucket and the call centre data S3 bucket.
 
 Data is encrypted at rest using [server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html) with Amazon S3 managed encryption keys (SSE-S3). Server-side encryption with AWS Key Management Service (AWS KMS) keys (SSE-KMS) or customer-provided keys (SSE-C) is explicitly blocked via an S3 bucket policy—by denying `PutObject` requests with the `aws:kms` header—to ensure that objects in the S3 bucket use the same server-side encryption method (i.e. SSE-S3).
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Infrastructure code for the provisioning of object storage for call centre data 
 
 ## Overview
 
-An S3 bucket is provisioned for the storage of call centre data, along with an IAM 'accessor' user with suitable policy and credentials, which is intended for use with client applications such as [WinSCP](https://winscp.net/eng/index.php) and [Cyberduck](https://cyberduck.io/) to retrieve and upload objects to the bucket.
+An S3 bucket is provisioned for the storage of call centre data, along with an IAM 'accessor' user with suitable policy and credentials, which is intended for use with client applications such as [WinSCP](https://winscp.net/eng/index.php) and [Cyberduck](https://cyberduck.io/) for managing objects in this buckets.
 
-An additionaal IAM 'migrator' user can be created by setting the boolean variable `data_migration_enabled` to `true` on a per-environment basis. This user is allowed to assume a role which permits retrieval of S3 objects from an external source bucket (specified by the `data_migration_source_bucket_arn` variable) for migration of data between an external S3 bucket and the call centre data S3 bucket.
+An additionaal IAM 'migrator' user can be created by setting the boolean variable `data_migration_enabled` to `true` on a per-environment basis. This user is allowed to assume a role which permits the retrieval of S3 objects from an external source bucket (specified by the `data_migration_source_bucket_arn` variable) and upload of objects to the call centre data bucket, and is intended for the migration of data between an external S3 bucket and the call centre data bucket.
 
 Data is encrypted at rest using [server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html) with Amazon S3 managed encryption keys (SSE-S3). Server-side encryption with AWS Key Management Service (AWS KMS) keys (SSE-KMS) or customer-provided keys (SSE-C) is explicitly blocked via an S3 bucket policy—by denying `PutObject` requests with the `aws:kms` header—to ensure that objects in the S3 bucket use the same server-side encryption method (i.e. SSE-S3).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Infrastructure code for the provisioning of object storage for call centre data 
 
 ## Overview
 
-An S3 bucket is provisioned for the storage of call centre data, along with an IAM 'accessor' user with suitable policy and credentials, which is intended for use with client applications such as [WinSCP](https://winscp.net/eng/index.php) and [Cyberduck](https://cyberduck.io/) for managing objects in this buckets.
+An S3 bucket is provisioned for the storage of call centre data, along with an IAM 'accessor' user with suitable policy and credentials, which is intended for use with client applications such as [WinSCP](https://winscp.net/eng/index.php) and [Cyberduck](https://cyberduck.io/) for managing objects in this bucket.
 
 An additionaal IAM 'migrator' user can be created by setting the boolean variable `data_migration_enabled` to `true` on a per-environment basis. This user is allowed to assume a role which permits the retrieval of S3 objects from an external source bucket (specified by the `data_migration_source_bucket_arn` variable) and upload of objects to the call centre data bucket, and is intended for the migration of data between an external S3 bucket and the call centre data bucket.
 

--- a/groups/storage/data.tf
+++ b/groups/storage/data.tf
@@ -31,6 +31,96 @@ data "aws_iam_policy_document" "data" {
   }
 }
 
+data "aws_iam_policy_document" "data_migration_execution" {
+  count = var.data_migration_enabled ? 1 : 0
+
+  statement {
+    sid = "AllowDataMigrationUserToListSourceBucket"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      "${var.data_migration_source_bucket_arn}"
+    ]
+  }
+
+  statement {
+    sid = "AllowDataMigrationUserToGetObjectsInSourceBucket"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionTagging"
+    ]
+
+    resources = [
+      "${var.data_migration_source_bucket_arn}/*"
+    ]
+  }
+
+  statement {
+    sid = "AllowDataMigrationUserToListDestinationBucket"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      aws_s3_bucket.data.arn
+    ]
+  }
+
+  statement {
+    sid = "AllowDataMigrationUserToPutObjectsInDestinationBucket"
+
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:PutObjectTagging",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionTagging"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.data.arn}/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "data_migration_trust" {
+  count = var.data_migration_enabled ? 1 : 0
+
+  statement {
+    sid = "AllowDataMigrationUserToAssumeThisRole"
+
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        aws_iam_user.data_migration[0].arn
+      ]
+    }
+  }
+}
+
 data "aws_iam_policy_document" "bucket" {
   statement {
     sid = "DenyPutObjectWithKmsEncryptionHeader"

--- a/groups/storage/iam.tf
+++ b/groups/storage/iam.tf
@@ -9,7 +9,7 @@ resource "aws_iam_access_key" "data" {
 
 resource "aws_iam_policy" "data" {
   name        = "${var.environment}-${var.service}-accessor"
-  description = "IAM policy for accessor user to retrieve objects in call centre data S3 bucket"
+  description = "IAM policy for accessor user to manage objects in call centre data S3 bucket"
   policy      = data.aws_iam_policy_document.data.json
   tags        = local.common_tags
 }

--- a/groups/storage/iam.tf
+++ b/groups/storage/iam.tf
@@ -32,7 +32,7 @@ resource "aws_iam_access_key" "data_migration" {
 
 resource "aws_iam_role" "data_migration" {
   count              = var.data_migration_enabled ? 1 : 0
-  name               = "${var.environment}-${var.service}-data-migration-role"
+  name               = "${var.environment}-${var.service}-data-migrator-role"
   assume_role_policy = data.aws_iam_policy_document.data_migration_trust[0].json
   tags               = local.common_tags
 }

--- a/groups/storage/iam.tf
+++ b/groups/storage/iam.tf
@@ -1,9 +1,6 @@
 resource "aws_iam_user" "data" {
-  name = "${var.environment}-${var.service}"
-
-  tags = merge(local.common_tags, {
-    Name = "${var.environment}-${var.service}-data-user"
-  })
+  name = "${var.environment}-${var.service}-accessor"
+  tags = local.common_tags
 }
 
 resource "aws_iam_access_key" "data" {
@@ -11,12 +8,45 @@ resource "aws_iam_access_key" "data" {
 }
 
 resource "aws_iam_policy" "data" {
-  name        = "${var.environment}-${var.service}-data-user-policy"
-  description = "IAM policy for data user to access objects in call centre data bucket"
+  name        = "${var.environment}-${var.service}-accessor"
+  description = "IAM policy for accessor user to retrieve objects in call centre data S3 bucket"
   policy      = data.aws_iam_policy_document.data.json
+  tags        = local.common_tags
 }
 
 resource "aws_iam_user_policy_attachment" "data" {
   user       = aws_iam_user.data.name
   policy_arn = aws_iam_policy.data.arn
+}
+
+resource "aws_iam_user" "data_migration" {
+  count = var.data_migration_enabled ? 1 : 0
+  name  = "${var.environment}-${var.service}-migrator"
+  tags  = local.common_tags
+}
+
+resource "aws_iam_access_key" "data_migration" {
+  count = var.data_migration_enabled ? 1 : 0
+  user  = aws_iam_user.data_migration[0].name
+}
+
+resource "aws_iam_role" "data_migration" {
+  count              = var.data_migration_enabled ? 1 : 0
+  name               = "${var.environment}-${var.service}-data-migration-role"
+  assume_role_policy = data.aws_iam_policy_document.data_migration_trust[0].json
+  tags               = local.common_tags
+}
+
+resource "aws_iam_policy" "data_migration" {
+  count       = var.data_migration_enabled ? 1 : 0
+  name        = "${var.environment}-${var.service}-migrator"
+  description = "IAM policy for migrator role to retrieve objects from external S3 bucket and write objects to call centre data S3 bucket"
+  policy      = data.aws_iam_policy_document.data_migration_execution[0].json
+  tags        = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "data_migration" {
+  count      = var.data_migration_enabled ? 1 : 0
+  role       = aws_iam_role.data_migration[0].name
+  policy_arn = aws_iam_policy.data_migration[0].arn
 }

--- a/groups/storage/variables.tf
+++ b/groups/storage/variables.tf
@@ -3,6 +3,18 @@ variable "aws_account" {
   description = "The name of the AWS account"
 }
 
+variable "data_migration_enabled" {
+  type        = bool
+  description = "A boolean value representing whether to create an IAM user and role for data migration across accounts"
+  default     = false
+}
+
+variable "data_migration_source_bucket_arn" {
+  type        = string
+  description = "The S3 source bucket ARN for data migration to the destination call centre data S3 bucket"
+  default     = ""
+}
+
 variable "region" {
   type        = string
   description = "The AWS region in which resources will be created"


### PR DESCRIPTION
This change introduces an optional set of resources—controlled by the `data_migration_enabled` variable—for migrating data from an external AWS account S3 bucket and the call centre data bucket under our control. This will be enabled at a later date for the `heritage-live-eu-west-2` profile, after confirmation of the source bucket ARN, and the `data_migration_source_bucket_arn` variable will be replaced with a secret sourced from Hashicorp Vault. These changes have been tested across accounts using the IAM migrator user and role.