### PR TITLE
Add support for KMS encrypted objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Data is encrypted at rest using [server-side encryption](https://docs.aws.amazon
 
 ## Branching Strategy
 
-This project uses a trunk-based branching strategy and infrastructure changes are versioned and applied from the `main` branch after merge via the [infrastructure pipeline](https://github.com/companieshouse/ci-pipelines/blob/master/pipelines/platform/team-platform/call-centre-data-terraform):
+This project uses a trunk-based branching strategy and infrastructure changes are versioned and applied from the `main` branch after merge via the [infrastructure pipeline](https://github.com/companieshouse/ci-pipelines/blob/master/pipelines/ssplatform/team-platform/call-centre-data-terraform):
 
 ```mermaid
 %%{init: { 'logLevel': 'debug', 'theme': 'default' , 'themeVariables': {

--- a/groups/storage/data.tf
+++ b/groups/storage/data.tf
@@ -110,7 +110,7 @@ data "aws_iam_policy_document" "data_migration_execution" {
         "kms:*"
       ]
 
-      resources =  [
+      resources = [
         var.data_migration_source_kms_key_arn
       ]
     }

--- a/groups/storage/data.tf
+++ b/groups/storage/data.tf
@@ -97,6 +97,24 @@ data "aws_iam_policy_document" "data_migration_execution" {
       "${aws_s3_bucket.data.arn}/*"
     ]
   }
+
+  dynamic "statement" {
+    for_each = var.data_migration_source_kms_key_arn != "" ? [1] : []
+
+    content {
+      sid = "AllowUseOfExternalKMSKey"
+
+      effect = "Allow"
+
+      actions = [
+        "kms:*"
+      ]
+
+      resources =  [
+        var.data_migration_source_kms_key_arn
+      ]
+    }
+  }
 }
 
 data "aws_iam_policy_document" "data_migration_trust" {

--- a/groups/storage/iam.tf
+++ b/groups/storage/iam.tf
@@ -31,10 +31,11 @@ resource "aws_iam_access_key" "data_migration" {
 }
 
 resource "aws_iam_role" "data_migration" {
-  count              = var.data_migration_enabled ? 1 : 0
-  name               = "${var.environment}-${var.service}-data-migrator-role"
-  assume_role_policy = data.aws_iam_policy_document.data_migration_trust[0].json
-  tags               = local.common_tags
+  count                = var.data_migration_enabled ? 1 : 0
+  name                 = "${var.environment}-${var.service}-data-migrator-role"
+  assume_role_policy   = data.aws_iam_policy_document.data_migration_trust[0].json
+  max_session_duration = 28800
+  tags                 = local.common_tags
 }
 
 resource "aws_iam_policy" "data_migration" {

--- a/groups/storage/variables.tf
+++ b/groups/storage/variables.tf
@@ -15,6 +15,12 @@ variable "data_migration_source_bucket_arn" {
   default     = ""
 }
 
+variable "data_migration_source_kms_key_arn" {
+  type        = string
+  description = "The ARN of the external KMS key that will be used when migrating data from the source bucket"
+  default     = ""
+}
+
 variable "region" {
   type        = string
   description = "The AWS region in which resources will be created"


### PR DESCRIPTION
This change introduces support for KMS encrypted objects in the source bucket and permits longer session durations for the migrator role to allow for long-running sync operations.