### PR TITLE
Remove phase one resources and adjust accessor policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Infrastructure code for the provisioning of object storage for call centre data 
 
 ## Overview
 
-An S3 bucket is provisioned for the storage of call centre data, along with an IAM 'accessor' user with suitable policy and credentials, which is intended for use with client applications such as [WinSCP](https://winscp.net/eng/index.php) and [Cyberduck](https://cyberduck.io/) for managing objects in this bucket.
-
-An additionaal IAM 'migrator' user can be created by setting the boolean variable `data_migration_enabled` to `true` on a per-environment basis. This user is allowed to assume a role which permits the retrieval of S3 objects from an external source bucket (specified by the `data_migration_source_bucket_arn` variable) and upload of objects to the call centre data bucket, and is intended for the migration of data between an external S3 bucket and the call centre data bucket.
+An S3 bucket is provisioned for the storage of call centre data, along with an IAM 'accessor' user with a read-only policy and AWS access key credentials that are intended for use with client applications such as AWS CLI, [WinSCP](https://winscp.net/eng/index.php), or [Cyberduck](https://cyberduck.io/).
 
 Data is encrypted at rest using [server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html) with Amazon S3 managed encryption keys (SSE-S3). Server-side encryption with AWS Key Management Service (AWS KMS) keys (SSE-KMS) or customer-provided keys (SSE-C) is explicitly blocked via an S3 bucket policy—by denying `PutObject` requests with the `aws:kms` header—to ensure that objects in the S3 bucket use the same server-side encryption method (i.e. SSE-S3).
 

--- a/groups/storage/data.tf
+++ b/groups/storage/data.tf
@@ -5,7 +5,8 @@ data "aws_iam_policy_document" "data" {
     effect = "Allow"
 
     actions = [
-      "s3:ListBucket"
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
     ]
 
     resources = [
@@ -14,128 +15,17 @@ data "aws_iam_policy_document" "data" {
   }
 
   statement {
-    sid = "AllowDataUserToPutAndGetObjectsInBucket"
+    sid = "AllowDataUserToGetObjectsInBucket"
 
     effect = "Allow"
 
     actions = [
-      "s3:PutObject",
-      "s3:PutObjectAcl",
-      "s3:GetObject",
-      "s3:GetObjectAcl"
+      "s3:GetObject"
     ]
 
     resources = [
       "${aws_s3_bucket.data.arn}/*"
     ]
-  }
-}
-
-data "aws_iam_policy_document" "data_migration_execution" {
-  count = var.data_migration_enabled ? 1 : 0
-
-  statement {
-    sid = "AllowDataMigrationUserToListSourceBucket"
-
-    effect = "Allow"
-
-    actions = [
-      "s3:ListBucket"
-    ]
-
-    resources = [
-      "${var.data_migration_source_bucket_arn}"
-    ]
-  }
-
-  statement {
-    sid = "AllowDataMigrationUserToGetObjectsInSourceBucket"
-
-    effect = "Allow"
-
-    actions = [
-      "s3:GetObject",
-      "s3:GetObjectTagging",
-      "s3:GetObjectVersion",
-      "s3:GetObjectVersionTagging"
-    ]
-
-    resources = [
-      "${var.data_migration_source_bucket_arn}/*"
-    ]
-  }
-
-  statement {
-    sid = "AllowDataMigrationUserToListDestinationBucket"
-
-    effect = "Allow"
-
-    actions = [
-      "s3:ListBucket"
-    ]
-
-    resources = [
-      aws_s3_bucket.data.arn
-    ]
-  }
-
-  statement {
-    sid = "AllowDataMigrationUserToPutObjectsInDestinationBucket"
-
-    effect = "Allow"
-
-    actions = [
-      "s3:PutObject",
-      "s3:PutObjectAcl",
-      "s3:PutObjectTagging",
-      "s3:GetObjectTagging",
-      "s3:GetObjectVersion",
-      "s3:GetObjectVersionTagging"
-    ]
-
-    resources = [
-      "${aws_s3_bucket.data.arn}/*"
-    ]
-  }
-
-  dynamic "statement" {
-    for_each = var.data_migration_source_kms_key_arn != "" ? [1] : []
-
-    content {
-      sid = "AllowUseOfExternalKMSKey"
-
-      effect = "Allow"
-
-      actions = [
-        "kms:*"
-      ]
-
-      resources = [
-        var.data_migration_source_kms_key_arn
-      ]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "data_migration_trust" {
-  count = var.data_migration_enabled ? 1 : 0
-
-  statement {
-    sid = "AllowDataMigrationUserToAssumeThisRole"
-
-    effect = "Allow"
-
-    actions = [
-      "sts:AssumeRole"
-    ]
-
-    principals {
-      type = "AWS"
-
-      identifiers = [
-        aws_iam_user.data_migration[0].arn
-      ]
-    }
   }
 }
 

--- a/groups/storage/iam.tf
+++ b/groups/storage/iam.tf
@@ -18,36 +18,3 @@ resource "aws_iam_user_policy_attachment" "data" {
   user       = aws_iam_user.data.name
   policy_arn = aws_iam_policy.data.arn
 }
-
-resource "aws_iam_user" "data_migration" {
-  count = var.data_migration_enabled ? 1 : 0
-  name  = "${var.environment}-${var.service}-migrator"
-  tags  = local.common_tags
-}
-
-resource "aws_iam_access_key" "data_migration" {
-  count = var.data_migration_enabled ? 1 : 0
-  user  = aws_iam_user.data_migration[0].name
-}
-
-resource "aws_iam_role" "data_migration" {
-  count                = var.data_migration_enabled ? 1 : 0
-  name                 = "${var.environment}-${var.service}-data-migrator-role"
-  assume_role_policy   = data.aws_iam_policy_document.data_migration_trust[0].json
-  max_session_duration = 28800
-  tags                 = local.common_tags
-}
-
-resource "aws_iam_policy" "data_migration" {
-  count       = var.data_migration_enabled ? 1 : 0
-  name        = "${var.environment}-${var.service}-migrator"
-  description = "IAM policy for migrator role to retrieve objects from external S3 bucket and write objects to call centre data S3 bucket"
-  policy      = data.aws_iam_policy_document.data_migration_execution[0].json
-  tags        = local.common_tags
-}
-
-resource "aws_iam_role_policy_attachment" "data_migration" {
-  count      = var.data_migration_enabled ? 1 : 0
-  role       = aws_iam_role.data_migration[0].name
-  policy_arn = aws_iam_policy.data_migration[0].arn
-}

--- a/groups/storage/profiles/heritage-live-eu-west-2/live/vars
+++ b/groups/storage/profiles/heritage-live-eu-west-2/live/vars
@@ -1,4 +1,2 @@
 aws_account = "heritage-live"
 environment = "live"
-
-data_migration_enabled = true

--- a/groups/storage/variables.tf
+++ b/groups/storage/variables.tf
@@ -3,24 +3,6 @@ variable "aws_account" {
   description = "The name of the AWS account"
 }
 
-variable "data_migration_enabled" {
-  type        = bool
-  description = "A boolean value representing whether to create an IAM user and role for data migration across accounts"
-  default     = false
-}
-
-variable "data_migration_source_bucket_arn" {
-  type        = string
-  description = "The S3 source bucket ARN for data migration to the destination call centre data S3 bucket"
-  default     = ""
-}
-
-variable "data_migration_source_kms_key_arn" {
-  type        = string
-  description = "The ARN of the external KMS key that will be used when migrating data from the source bucket"
-  default     = ""
-}
-
 variable "region" {
   type        = string
   description = "The AWS region in which resources will be created"


### PR DESCRIPTION
This pull request includes the follow changes:

- Remove all resources related to phase one of the data migration
- Adjust the accessor user IAM policy to permit read-only access to objects in the S3 bucket (suitable for performing `aws sync ...` operations)