### PR TITLE
Add Dependabot registry config for private repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
       interval: "weekly"
     reviewers:
       - "companieshouse/platform-admin"
+    registries:
+      - github-dependabot
+registries:
+  github-dependabot:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{secrets.DEPENDABOT_GITHUB_ACCESS_TOKEN}}


### PR DESCRIPTION
This change introduces Dependabot configuration to fix failing updates after the introduction of changes that require access to private Terraform repositories.
