### PR TITLE
Relax upper version constraint for Dependabot

### DIFF
--- a/groups/storage/main.tf
+++ b/groups/storage/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/groups/storage/main.tf
+++ b/groups/storage/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0, < 1.4.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
This change introduces a fix for Dependabot updates failing due to the Terraform version constraint being too low:

```hcl
Error: Unsupported Terraform Core version

  on main.tf line 2, in terraform:
   2:   required_version = ">= 1.3.0, < 1.4.0"

This configuration does not support Terraform version 1.12.2. To proceed,
either choose another supported Terraform version or update this version
constraint. Version constraints are normally set for good reason, so updating
the constraint may lead to other errors or unexpected behavior.
```