### PR TITLE
Disable S3 bucket keys

### DIFF
--- a/groups/storage/s3.tf
+++ b/groups/storage/s3.tf
@@ -14,7 +14,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
   bucket = aws_s3_bucket.data.id
 
   rule {
-    bucket_key_enabled = true
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }


### PR DESCRIPTION
This change disables [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html) — a cost-optimisation feature only applicable when using `SSE-KMS`. AWS APIs may omit or ignore this setting when `AES256` (i.e. `SSE-S3`) is configured, which can lead to Terraform repeatedly detecting a difference between configuration and observed state.